### PR TITLE
feat: initial prometheus metrics port

### DIFF
--- a/examples/metrics/server.js
+++ b/examples/metrics/server.js
@@ -1,0 +1,55 @@
+const express = require('express')
+const { makeExecutableSchema } = require('graphql-tools')
+
+const { ApolloVoyagerServer, gql } = require('../../packages/apollo-voyager-server')
+const { getMetrics, responseLoggingMetric } = require('../../packages/apollo-voyager-metrics')
+
+// This is our Schema Definition Language (SDL)
+const typeDefs = gql`
+  type Query {
+    hello: String
+  }
+`
+
+// Resolver functions. This is our business logic
+const resolvers = {
+  Query: {
+    hello: (obj, args, context, info) => {
+      
+      // we can access the request object provided by the Voyager framework
+      console.log(context.request.body)
+      
+      // we can access the context added below also
+      console.log(context.serverName)
+      return `Hello world from ${context.serverName}`
+    }
+  }
+}
+
+const schema = makeExecutableSchema({ typeDefs, resolvers })
+
+// The context is a function or object that can add some extra data
+// That will be available via the `context` argument the resolver functions
+const context = async ({ req }) => {
+  // add some context to GraphQL requests
+  console.log('my context provider')
+  return { serverName: 'Voyager Server' }
+}
+
+// Initialize the apollo voyager server with our schema and context
+const server = ApolloVoyagerServer({ 
+  schema,
+  context
+})
+
+const app = express()
+app.use(responseLoggingMetric)
+app.use('/metrics', getMetrics)
+
+
+server.applyMiddleware({ app })
+
+const port = 4000
+app.listen({ port }, () =>
+  console.log(`🚀 Server ready at http://localhost:${port}${server.graphqlPath}`)
+)

--- a/examples/package.json
+++ b/examples/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@aerogear/apollo-voyager-keycloak": "1.0.0",
     "@aerogear/apollo-voyager-server": "1.0.0",
+    "@aerogear/apollo-voyager-metrics": "1.0.0",
     "express": "^4.16.4",
     "graphql": "^14.0.2",
     "graphql-tools": "^4.0.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1433,6 +1433,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -5270,6 +5275,14 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
+    "prom-client": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.2.0.tgz",
+      "integrity": "sha512-4gUAq/GR5C8q5eWxOa7tA60AtmkMpbyBd/2btCayvd3h/7HzS0p/kESKRwggJgbFrfdhTCBpOwPAwKiI01Q0VQ==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -6259,6 +6272,14 @@
         "block-stream": "*",
         "fstream": "^1.0.2",
         "inherits": "2"
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
       }
     },
     "temp-dir": {

--- a/packages/apollo-voyager-metrics/package-lock.json
+++ b/packages/apollo-voyager-metrics/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "@aerogear/apollo-voyager-metrics",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
+    "prom-client": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.2.0.tgz",
+      "integrity": "sha512-4gUAq/GR5C8q5eWxOa7tA60AtmkMpbyBd/2btCayvd3h/7HzS0p/kESKRwggJgbFrfdhTCBpOwPAwKiI01Q0VQ==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
+      }
+    }
+  }
+}

--- a/packages/apollo-voyager-metrics/package.json
+++ b/packages/apollo-voyager-metrics/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@aerogear/apollo-voyager-metrics",
+  "version": "1.0.0",
+  "description": "> TODO: description",
+  "author": "AeroGear Team<aerogear@googlegroups.com>",
+  "homepage": "http://aerogear.org",
+  "license": "Apache-2.0",
+  "main": "dist/index.js",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "compile": "tsc --build tsconfig.json",
+    "watch": "tsc --build tsconfig.json --watch",
+    "compile:clean": "tsc --build tsconfig.json --clean",
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  },
+  "dependencies": {
+    "prom-client": "^11.2.0",
+    "@aerogear/apollo-voyager-tools": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/graphql": "^14.0.3",
+    "@types/node": "^10.12.10",
+    "typescript": "^3.1.6"
+  }
+}

--- a/packages/apollo-voyager-metrics/src/index.ts
+++ b/packages/apollo-voyager-metrics/src/index.ts
@@ -1,0 +1,96 @@
+import Prometheus from 'prom-client'
+import { buildPath } from '@aerogear/apollo-voyager-tools'
+import { IncomingMessage } from 'http'
+import { Response } from 'express'
+
+interface ResponseWithVoyagerMetrics extends Response {
+  requestStart: number
+}
+
+Prometheus.collectDefaultMetrics()
+
+const resolverTimingMetric = new Prometheus.Histogram({
+  name: 'resolver_timing_ms',
+  help: 'Resolver response time in milliseconds',
+  labelNames: ['datasource_type', 'operation_type', 'name']
+})
+
+const resolverRequestsMetric = new Prometheus.Counter({
+  name: 'requests_resolved',
+  help: 'Number of requests resolved by server',
+  labelNames: ['datasource_type', 'operation_type', 'path']
+})
+
+const resolverRequestsTotalMetric = new Prometheus.Counter({
+  name: 'requests_resolved_total',
+  help: 'Number of requests resolved by server in total',
+  labelNames: ['datasource_type', 'operation_type', 'path']
+})
+
+const serverResponseMetric = new Prometheus.Histogram({
+  name: 'server_response_ms',
+  help: 'Server response time in milliseconds',
+  labelNames: ['request_type', 'error']
+})
+
+export function getMetrics (req: IncomingMessage, res: Response) {
+  res.set('Content-Type', Prometheus.register.contentType)
+  res.end(Prometheus.register.metrics())
+
+  resolverTimingMetric.reset()
+  resolverRequestsMetric.reset()
+  serverResponseMetric.reset()
+}
+
+export function responseLoggingMetric (req: IncomingMessage, res: ResponseWithVoyagerMetrics, next: Function) {
+  const requestMethod = req.method as string
+
+  res.requestStart = Date.now()
+
+  res.on('finish', onResFinished)
+  res.on('error', onResFinished)
+
+  if (next) next()
+
+  function onResFinished (err: any) {
+    res.removeListener('error', onResFinished)
+    res.removeListener('finish', onResFinished)
+    const responseTime = Date.now() - res.requestStart
+
+    const requestFailed = (err !== undefined || res.statusCode > 299)
+
+    serverResponseMetric
+      .labels(requestMethod, String(requestFailed))
+      .observe(responseTime)
+  }
+}
+
+export function updateResolverMetrics (resolverInfo: any, responseTime: number) {
+  const {
+    operation: {operation: resolverMappingType},
+    fieldName: resolverMappingName,
+    path: resolverWholePath,
+    parentType: resolverParentType,
+    dataSourceType
+  } = resolverInfo
+
+  resolverTimingMetric
+    .labels(dataSourceType, resolverMappingType, resolverMappingName)
+    .observe(responseTime)
+
+  resolverRequestsMetric
+    .labels(
+      dataSourceType,
+      resolverMappingType,
+      `${resolverParentType}.${buildPath(resolverWholePath)}`
+    )
+    .inc(1)
+
+  resolverRequestsTotalMetric
+    .labels(
+      dataSourceType,
+      resolverMappingType,
+      `${resolverParentType}.${buildPath(resolverWholePath)}`
+    )
+    .inc(1)
+}

--- a/packages/apollo-voyager-metrics/tsconfig.json
+++ b/packages/apollo-voyager-metrics/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": []
+}

--- a/packages/apollo-voyager-tools/package-lock.json
+++ b/packages/apollo-voyager-tools/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "@aerogear/apollo-voyager-tools",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "typescript": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "dev": true
+    }
+  }
+}

--- a/packages/apollo-voyager-tools/package.json
+++ b/packages/apollo-voyager-tools/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@aerogear/apollo-voyager-tools",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "compile": "tsc --build tsconfig.json",
+    "watch": "tsc --build tsconfig.json --watch",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "compile:clean": "tsc --build tsconfig.json --clean"
+  },
+  "author": "AeroGear Team<aerogear@googlegroups.com>",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "typescript": "^3.1.6"
+  }
+}

--- a/packages/apollo-voyager-tools/src/buildPath.ts
+++ b/packages/apollo-voyager-tools/src/buildPath.ts
@@ -1,0 +1,22 @@
+/**
+ * builds path for a GraphQL operation
+ * examples:
+ - top level resolver : allMemes
+ - nested resolver    : allMemes.0.owner
+ * @param path - GraphQL path object
+ * @returns {string} the path built
+ */
+export function buildPath (path: any): String {
+  let pathItems = []
+  let currPath = path
+  while (currPath) {
+    // currPath.key could be "0", so can't use falsy test
+    if (currPath.key === undefined || currPath.key === null) {
+      break
+    }
+    pathItems.unshift(currPath.key) // prepend
+    currPath = currPath.prev
+  }
+
+  return pathItems.join('.')
+}

--- a/packages/apollo-voyager-tools/src/index.ts
+++ b/packages/apollo-voyager-tools/src/index.ts
@@ -1,0 +1,1 @@
+export * from './buildPath'

--- a/packages/apollo-voyager-tools/tsconfig.json
+++ b/packages/apollo-voyager-tools/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": []
+}


### PR DESCRIPTION
This PR is pretty much a copy-paste of the old metrics module from the sync server.

One of the important metrics that needs to be collected is resolver timings. I imagine we will need to implement some sort of wrapper that the user can choose to enable as part of overall metrics. This PR does not include a solution for this.

My suggestion is that we merge this PR without verification as I have another PR around CircleCI that I want to get merged ASAP. Then we can work out the resolver timing solution.