### PR TITLE
fix: Disable lint for test that can lead to unnecessary improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "echo ok",
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean --yes",
-    "lint": "tslint '*/*/src/**/*.ts' '*/*/test/**/*.ts'",
+    "lint": "tslint '*/*/src/**/*.ts'",
     "format": "tslint '*/*/src/**/*.ts' '*/*/test/**/*.ts' --fix",
     "cleanInstall": "lerna exec npm install --ignore-scripts",
     "compile": "lerna exec -- npm run compile",


### PR DESCRIPTION
Linting source code is enough to guarantee quality. 
Linting tests can bring a lots of modifications when migrating tests from server.
We still need to keep format option to format source code, but let's not fail on errors in tests.