### PR TITLE
doc: add license, issue & PR templates, contributor guides, codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @wtrocki @darahayes @StephenCoady @danielpassos

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Thank you for reporting an issue.
+
+Please fill in as much of the template below as you can.
+
+Module: if known, please specify the affected module name. (examples: apollo-voyager-server, apollo-voyager-context)
+Version: version of the affected module
+
+
+If possible, please provide code that demonstrates the problem, keeping it as
+simple and free of external dependencies as you can.
+-->
+
+* **Module**:
+* **Version**:
+
+<!-- Please provide more details below this comment. -->

--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,0 +1,23 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us improve
+
+---
+
+<!--
+Thank you for reporting a possible bug in Apollo Voyager Server
+
+Please fill in as much of the template below as you can.
+
+Module: if known, please specify the affected module name. (examples: apollo-voyager-server, apollo-voyager-context)
+Version: version of the affected module
+
+
+If possible, please provide code that demonstrates the problem, keeping it as
+simple and free of external dependencies as you can.
+-->
+
+* **Module**:
+* **Version**:
+
+<!-- Please provide more details below this comment. -->

--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -19,5 +19,6 @@ simple and free of external dependencies as you can.
 
 * **Module**:
 * **Version**:
+* **Node.js / npm versions:**
 
-<!-- Please provide more details below this comment. -->
+<!-- Please provide more details and steps to reproduce the issue below this comment. -->

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F680 Feature request"
+about: Suggest an idea for this project
+
+---
+
+<!--
+Thank you for suggesting an idea to make Apollo Voyager Server better.
+
+Please fill in as much of the template below as you're able.
+-->
+
+**Is your feature request related to a problem? Please describe.**
+Please describe the problem you are trying to solve.
+
+**Describe the solution you'd like**
+Please describe the desired behavior.
+
+**Describe alternatives you've considered**
+Please describe alternative solutions or features you have considered.

--- a/.github/ISSUE_TEMPLATE/3-help.md
+++ b/.github/ISSUE_TEMPLATE/3-help.md
@@ -1,0 +1,14 @@
+---
+name: "⁉️ Need help with Apollo Voyager Server?"
+about: Please file an issue in our repo.
+
+---
+
+
+If you have a question about Apollo Voyager Server that is not a bug report or feature
+request, feel free to post it here.
+
+You can also reach the aerogear team at [#aerogear](ircs://chat.freenode.net:6697/aerogear) on [Freenode IRC](https://freenode.net/) or the 
+[aerogear google group](https://groups.google.com/forum/#!forum/aerogear).
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,4 @@ Contributors guide: https://github.com/aerogear/apollo-voyager-server/blob/maste
 - [ ] `npm test` passes
 - [ ] tests are included
 - [ ] documentation is changed or added
-- [ ] commit message follows [commit guidelines](https://github.com/aerogear/apollo-voyager-server/blob/master/CONTRIBUTING.md#commit-message-guidelines)
+- [ ] commit message follows [commit guidelines](../doc/guides/pull-requests.md#commit-message-guidelines)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Contributors guide: https://github.com/aerogear/apollo-voyager-server/blob/maste
 
 ### Description
 
-<!-- Please provide a description of your pull request -->
+<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->
 
 ##### Checklist
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--
+Thank you for your pull request. Please provide a description above and review
+the requirements below.
+
+Bug fixes and new features should include tests.
+
+Contributors guide: https://github.com/aerogear/apollo-voyager-server/blob/master/CONTRIBUTING.md
+-->
+
+### Description
+
+<!-- Please provide a description of your pull request -->
+
+##### Checklist
+<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+
+- [ ] `npm test` passes
+- [ ] tests are included
+- [ ] documentation is changed or added
+- [ ] commit message follows [commit guidelines](https://github.com/aerogear/apollo-voyager-server/blob/master/CONTRIBUTING.md#commit-message-guidelines)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,47 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at #aerogear channel on freenode IRC or via aerogear@googlegroups.com, see [AeroGear forum](https://groups.google.com/forum/#!forum/aerogear). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+For more information about the AeroGear community and project , visit [our website](https://aerogear.org/community/).
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing to Apollo Voyager Server
+
+## Issues
+
+* [Opening Issues](./doc/guides/issues.md)
+* [Asking for Help](./doc/guides/issues.md#asking-for-help)
+
+## Pull Requests
+
+* [Setting up Your Local Environment](./doc/guides/local-development.md#setting-up-your-local-environment)
+* [The Process of Making Changes](./doc/guides/pull-requests.md#the-process-of-making-changes)
+
+## Code of Conduct
+
+The Apollo Voyager Server project has a
+[Code of Conduct](./CODE_OF_CONDUCT.md)
+to which all contributors must adhere.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Red Hat Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -10,125 +10,17 @@ The project does this by taking the popular [Apollo Server](https://www.apollogr
 
 **Warning:** This project is under heavy development and is not recommended for production usage.
 
-# Requirements
+## Local Development Setup
 
-* Node.js `v8.12.0` or higher
-* TypeScript `3.1.6`
-* Lerna `3.4.3`
+The [Local Development Guide](./doc/guides/local-development.md) will help contributors to get started developing Apollo Voyager Server.
 
-# Getting Started
+## Contributing
 
-Install the top level dependencies.
+The [Contributing Guide](./CONTRIBUTING.md) will give you all of the information you need to ask for help, open Issues and open Pull Requests.
 
-```
-npm install
-```
+## Examples
 
-Set up the project. This installs the dependencies in all of the sub packages and ensures packages are linked together for local development.
+The [Examples Guide](./doc/guides/examples.md) walks through some example applications which highlight some of Apollo Voyager Server's features.
 
-```
-npm run bootstrap
-```
-
-Compile the project.
-
-```
-npm run compile
-```
-
-# Examples
-
-The `examples` directory has example scripts that show how the Voyager framework can be used.
-
-If you have run the `npm run bootstrap` command, the dependencies should already be installed.
-
-## Basic Example
-
-`basic/server.js` is the simplest example of how to use the `apollo-voyager-server` framework.
-
-```
-$ node examples/basic/server.js
-🚀 Server ready at http://localhost:4000/graphql
-```
-
-Open [http://localhost:4000/graphql](http://localhost:4000/graphql) and you will see the GraphQL Playground. This is a space where you can try out queries and see the results.
-
-Try the following query.
-
-```
-query hello {
-  hello
-}
-```
-
-## Keycloak Example
-
-`keycloak/server.js` shows how we can use the `KeycloakSecurityService` from `apollo-voyager-keycloak` to protect our app with Keycloak.
-
-This example shows 
-
-* How to set up authentication on the `/graphql` endpoint
-* How to add role based access control on a Schema level using the `@hasRole` directive.
-
-### Keycloak Setup
-
-This example requires some extra setup. A `docker-compose.yml` file has been included to simplify a local keycloak setup.
-
-The following steps set up a local keycloak instance, configures the instance for an example application and sets up a user that we can log into the application.
-
-```
-cd examples/keycloak/config
-docker-compose up
-```
-
-* Open [http://localhost:8080/auth/admin/](http://localhost:8080/auth/admin/) and login with the user `admin` and password `admin`.
-* Click **Add Realm** and click **Select File** next to the **Import** label.
-* Select the [examples/keycloak/config/realm-export.json](examples/keycloak/config/realm-export.json) file and click **Create**.
-* Click **Users** and add a new user called `developer`. You can choose your own name if you wish.
-* Under the **Credentials** tab add a new password of **developer** and make sure it is not temporary. You can choose your own password if you wish.
-* Under the **Role Mappings** tab assign the **admin** realm role.
-* Select the **voyager-testing** option from the **Client Roles** dropdown and assign the **admin** role.
-
-### Start the Server
-
-```
-node examples/keycloak/server.js
-Initializing Keycloak authentication
-🚀 Server ready at http://localhost:4000/graphql
-```
-
-Open [http://localhost:4000/graphql](http://localhost:4000/graphql) and you will be redirected to a login page. Log in with the user that was created earlier you should now see the the GraphQL playground.
-
-In the playground you will see an error.
-
-```json
-{
-  "error": "Failed to fetch schema. Please check your connection"
-}
-```
-
-Do not worry, this error is caused by the playground making unauthenticated requests. One more step is needed.
-
-In a new tab, open [http://localhost:4000/token](http://localhost:4000/token). You should see a JSON result.
-
-```json
-{"Authorization":"Bearer <Long String of Characters>"}
-```
-
-Copy the entire JSON result to your clipboard and navigate back to the Playground at [http://localhost:4000/graphql](http://localhost:4000/graphql). 
-
-In the Playground, click the **HTTP Headers** button and paste the JSON result into the input box. If successful, the error will disappear and it is now possible to make queries.
-
-Try out the following query
-
-```
-query hello {
-  hello
-}
-```
-
-### Role Based Access Control
-
-The query above will only work if the authenticated user has the `admin` role. You can see this rule being applied with the `@hasRole(role: "admin")` directive in [examples/keycloak/server.js](examples/keycloak/server.js#L22).
-
-Try change the the role to a made up role and restart the server. Try the sample query again and verify that an error is displayed.
+* [Basic Example Application](./doc/guides/examples.md#basic-example) - This typical hello world example shows how to set up Apollo Voyager Server.
+* [Application with Authentication and RBAC](./doc/guides/examples.md#keycloak-example) - This example shows how to add authentication and and role based access control to your application using [Keycloak](https://www.keycloak.org/)

--- a/doc/guides/examples.md
+++ b/doc/guides/examples.md
@@ -1,0 +1,96 @@
+# Apollo Voyager Server Examples
+
+The `examples` directory has example applications that show how the Voyager framework can be used.
+
+If you have run the `npm run bootstrap` command, the dependencies should already be installed.
+
+## Basic Example
+
+`basic/server.js` is the simplest example of how to use the `apollo-voyager-server` framework.
+
+```
+$ node examples/basic/server.js
+🚀 Server ready at http://localhost:4000/graphql
+```
+
+Open [http://localhost:4000/graphql](http://localhost:4000/graphql) and you will see the GraphQL Playground. This is a space where you can try out queries and see the results.
+
+Try the following query.
+
+```
+query hello {
+  hello
+}
+```
+
+## Keycloak Example
+
+`keycloak/server.js` shows how we can use the `KeycloakSecurityService` from `apollo-voyager-keycloak` to protect our app with Keycloak.
+
+This example shows 
+
+* How to set up authentication on the `/graphql` endpoint
+* How to add role based access control on a Schema level using the `@hasRole` directive.
+
+### Keycloak Setup
+
+This example requires some extra setup. A `docker-compose.yml` file has been included to simplify a local keycloak setup.
+
+The following steps set up a local keycloak instance, configures the instance for an example application and sets up a user that we can log into the application.
+
+```
+cd examples/keycloak/config
+docker-compose up
+```
+
+* Open [http://localhost:8080/auth/admin/](http://localhost:8080/auth/admin/) and login with the user `admin` and password `admin`.
+* Click **Add Realm** and click **Select File** next to the **Import** label.
+* Select the [examples/keycloak/config/realm-export.json](examples/keycloak/config/realm-export.json) file and click **Create**.
+* Click **Users** and add a new user called `developer`. You can choose your own name if you wish.
+* Under the **Credentials** tab add a new password of **developer** and make sure it is not temporary. You can choose your own password if you wish.
+* Under the **Role Mappings** tab assign the **admin** realm role.
+* Select the **voyager-testing** option from the **Client Roles** dropdown and assign the **admin** role.
+
+### Start the Server
+
+```
+node examples/keycloak/server.js
+Initializing Keycloak authentication
+🚀 Server ready at http://localhost:4000/graphql
+```
+
+Open [http://localhost:4000/graphql](http://localhost:4000/graphql) and you will be redirected to a login page. Log in with the user that was created earlier you should now see the the GraphQL playground.
+
+In the playground you will see an error.
+
+```json
+{
+  "error": "Failed to fetch schema. Please check your connection"
+}
+```
+
+Do not worry, this error is caused by the playground making unauthenticated requests. One more step is needed.
+
+In a new tab, open [http://localhost:4000/token](http://localhost:4000/token). You should see a JSON result.
+
+```json
+{"Authorization":"Bearer <Long String of Characters>"}
+```
+
+Copy the entire JSON result to your clipboard and navigate back to the Playground at [http://localhost:4000/graphql](http://localhost:4000/graphql). 
+
+In the Playground, click the **HTTP Headers** button and paste the JSON result into the input box. If successful, the error will disappear and it is now possible to make queries.
+
+Try out the following query
+
+```
+query hello {
+  hello
+}
+```
+
+### Role Based Access Control
+
+The query above will only work if the authenticated user has the `admin` role. You can see this rule being applied with the `@hasRole(role: "admin")` directive in [examples/keycloak/server.js](examples/keycloak/server.js#L22).
+
+Try change the the role to a made up role and restart the server. Try the sample query again and verify that an error is displayed.

--- a/doc/guides/issues.md
+++ b/doc/guides/issues.md
@@ -1,0 +1,17 @@
+# Opening Issues
+
+## JIRA
+
+The AeroGear team tracks issues for all of the AeroGear projects in the [AeroGear Project](https://issues.jboss.org/projects/AEROGEAR/issues) in the [JBoss Developer JIRA](https://issues.jboss.org). We do prefer if you sign up and create issues there. See the [AeroGear JIRA Usage and Guidelines Guide](https://aerogear.org/docs/guides/JIRAUsage/) for information on how the issue tracker relates to contributions to this project.
+
+## GitHub
+
+We understand that for some people, JIRA can be a barrier to entry for creating issues and contributing in general. The maintainers of the Apollo Voyager Server welcome issues created in GitHub. Feel free to [Create an Issue](https://github.com/aerogear/apollo-voyager-server/issues/new) and select from one of our issue templates. We will do our best to triage these issues in GitHub.
+
+## Asking for Help
+
+If you have a question about Apollo Voyager Server that is not a bug report or feature
+request, feel free to [create an issue using the help issue template](https://github.com/aerogear/apollo-voyager-server/issues/new?template=3-help.md).
+
+You can also reach the aerogear team at [#aerogear](ircs://chat.freenode.net:6697/aerogear) on [Freenode IRC](https://freenode.net/) or the 
+[aerogear google group](https://groups.google.com/forum/#!forum/aerogear).

--- a/doc/guides/local-development.md
+++ b/doc/guides/local-development.md
@@ -1,0 +1,38 @@
+# Local Development Guide
+
+## Requirements
+
+* Git
+* Node.js `v8.12.0` or higher. We recommend you install and manage Node.js versions using [Node Version Manager (nvm)](https://github.com/creationix/nvm)
+
+### Setting up Your Local Environment
+
+Install the top level dependencies.
+
+```
+npm install
+```
+
+Set up the project. This installs the dependencies in all of the sub packages and ensures packages are linked together for local development.
+
+```
+npm run bootstrap
+```
+
+Compile the project.
+
+```
+npm run compile
+```
+
+Run the tests.
+
+```
+npm test
+```
+
+Run the linter.
+
+```
+npm run lint
+```

--- a/doc/guides/pull-requests.md
+++ b/doc/guides/pull-requests.md
@@ -60,7 +60,7 @@ This project has rules for commit messages (loosely based on [Conventional Commi
 
 We like short commit messages. But we also like some structure. It's very simple.
 
-TL;DR just add one of `fix:`, `feat:`, `breaking:` to the beginning of your commit.
+Simply add add one of `fix:`, `feat:`, `breaking:` to the beginning of your commit.
 
 Examples:
 
@@ -68,7 +68,13 @@ Examples:
   - feat: add RBAC feature to keycloak module.
   - breaking: renamed apollo server constructor
 
-Please note you can also choose from one of the following if you think one is more appropriate.
+The reasons for this are as follows:
+
+* Commit messages are more readable, especially when looking through the **project history**.
+* Commit messages describe whether a major, minor or patch change has been introduced (see [semver.org](https://semver.org/))
+* Commit messages can be used to generate a changelog.
+
+Please note you can also choose from one of the following key words if you think one is more appropriate.
 
 - `doc`: Documentation only changes
 - `test`: Adding missing tests or correcting existing tests

--- a/doc/guides/pull-requests.md
+++ b/doc/guides/pull-requests.md
@@ -1,0 +1,176 @@
+
+
+## Pull Requests
+
+### Step 1: Fork the project
+
+Fork the project [on GitHub](https://github.com/aerogear/apollo-voyager-server) and clone your fork
+locally.
+
+```text
+$ git clone git@github.com:username/apollo-voyager-server.git
+$ cd apollo-voyager-server
+$ git remote add upstream https://github.com/aerogear/apollo-voyager-server.git
+$ git fetch upstream
+```
+
+It is recommended to configure `git` so that it knows who you are:
+
+```text
+$ git config user.name "J. Random User"
+$ git config user.email "j.random.user@example.com"
+```
+
+This will help us add your details to our list of contributors and to our changelog.
+
+### Step 2: Create a New Branch
+
+As a best practice to keep your development environment as organized as
+possible, create local branches to work within. These should also be created
+directly off of the `master` branch.
+
+```text
+$ git checkout -b my-branch -t upstream/master
+```
+
+## The Process of Making Changes
+
+### Step 3: Code
+
+To learn how to make changes, build and test our code, please follow our [Local Development Guide](./local-development.md).
+
+### Step 4: Commit
+
+It is a recommended best practice to make small individual commits. There is no limit to the number of
+commits any single Pull Request may have, and some contributors find it easier
+to review changes that are split across multiple commits.
+
+```text
+$ git add my/changed/files
+$ git commit
+```
+
+Note that multiple commits often get squashed by mainteiners when they are landed.
+
+## Commit Message Guidelines
+
+This project has rules for commit messages (loosely based on [Conventional Commits](https://conventionalcommits.org/)).
+
+### Commit Message Format
+
+A good commit message should describe what changed and why.
+
+1. The first line should
+  
+    - Be prefixed with one of `fix(module):`, `feat(module):`, or `breaking(module):`, where `fix` represents a semver patch change, `feat` represents a semver minor change and `breaking` represents a semver major change.
+    - `module` should reference the affected module. All our module names follow the convention `apollo-voyager-<name>`. `module` should be the `<name>` part only.
+    - Contain a short description of the change in all lowercase characters. Try to keep the first line shorter tham 100 characters.
+
+    Examples:
+
+    - fix(server): add new options to ApolloVoyagerServerOptions interface
+    - feat(keycloak): add RBAC feature to keycloak package.
+
+    Please note you can also choose from one of the following if you think one is more appropriate:
+
+    - `doc`: Documentation only changes
+    - `test`: Adding missing tests or correcting existing tests
+    - `refactor`: A code change that neither fixes a bug nor adds a feature
+    - `ci`: Changes to our CI configuration files and scripts.
+
+2. Keep the second line blank
+
+3. Try to keep all lines under 100 characters
+
+4. If your commit fixes an open issue, you can add a reference to it at the end of the log.
+
+    Examples:
+
+      - Fixes: https://issues.jboss.org/browse/AEROGEAR-8195
+      - Refs: https://issues.jboss.org/browse/AEROGEAR-8195
+
+5. If your commit introduces a breaking change (Semver Major), your commit message
+should explain what the breaking change is, the reason it was introduced, and which
+situation would trigger the breaking change.
+
+Sample complete commit message:
+
+```txt
+fix(module): explain the commit in one line
+
+Body of commit message is a few lines of text, explaining things
+in more detail, possibly giving some background about the issue
+being fixed, etc.
+
+Body of commit message may have multiple paragraphs if you wish.
+Please make sure the paragraphs are under 100 characters.
+
+Fixes: https://issues.jboss.org/browse/AEROGEAR-8192
+Refs: https://issues.jboss.org/browse/AEROGEAR-8193
+```
+
+### Step 5: Rebase
+
+As a best practice, once you have committed your changes, it is a good idea
+to use `git rebase` to synchronize your work with the main
+repository.
+
+```text
+$ git fetch upstream
+$ git rebase upstream/master
+```
+
+### Step 6: Test
+
+<!-- TODO: Once we have more testing in place, it would be nice to have a better guide on tests -->
+Bug fixes and features should always come with tests. This repo mostly contains `unit` and `integration` tests.
+Unit tests are typically placed in the same directory as the code they are testing. 
+Looking at other tests to see how they should be structured can help you write tests.
+
+Before submitting your changes in a Pull Request, always run the full test suite and lint the code.
+
+```
+$ npm test
+$ npm run lint
+```
+
+### Step 7: Push
+
+Once you are sure your commits are ready to go, with passing tests and linting,
+begin the process of opening a Pull Request by pushing your working branch to
+your fork on GitHub.
+
+```text
+$ git push origin my-branch
+```
+
+### Step 8: Opening the Pull Request
+
+From within GitHub, opening a new Pull Request will present you with a template
+that should be filled out:
+
+```markdown
+<!--
+Thank you for your pull request. Please provide a description above and review
+the requirements below.
+
+Bug fixes and new features should include tests.
+
+Contributors guide: https://github.com/aerogear/apollo-voyager-server/blob/master/CONTRIBUTING.md
+-->
+
+### Description
+
+<!-- Please provide a description of your pull request -->
+
+##### Checklist
+<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
+
+- [ ] `npm test` passes
+- [ ] tests are included
+- [ ] documentation is changed or added
+- [ ] commit message follows [commit guidelines](https://github.com/aerogear/apollo-voyager-server/blob/master/CONTRIBUTING.md#commit-message-guidelines)
+```
+
+Please try to do your best at filling out the details, but feel free to skip
+parts if you're not sure what to put.

--- a/doc/guides/pull-requests.md
+++ b/doc/guides/pull-requests.md
@@ -58,52 +58,22 @@ This project has rules for commit messages (loosely based on [Conventional Commi
 
 ### Commit Message Format
 
-A good commit message should describe what changed and why.
+We like short commit messages. But we also like some structure. It's very simple.
 
-1. The first line should
-  
-    - Be prefixed with one of `fix(module):`, `feat(module):`, or `breaking(module):`, where `fix` represents a semver patch change, `feat` represents a semver minor change and `breaking` represents a semver major change.
-    - `module` should reference the affected module. All our module names follow the convention `apollo-voyager-<name>`. `module` should be the `<name>` part only.
-    - Contain a short description of the change in all lowercase characters. Try to keep the first line shorter tham 100 characters.
+TL;DR just add one of `fix:`, `feat:`, `breaking:` to the beginning of your commit.
 
-    Examples:
+Examples:
 
-    - fix(server): add new options to ApolloVoyagerServerOptions interface
-    - feat(keycloak): add RBAC feature to keycloak package.
+  - fix: ensure server starts correctly
+  - feat: add RBAC feature to keycloak module.
+  - breaking: renamed apollo server constructor
 
-    Please note you can also choose from one of the following if you think one is more appropriate:
+Please note you can also choose from one of the following if you think one is more appropriate.
 
-    - `doc`: Documentation only changes
-    - `test`: Adding missing tests or correcting existing tests
-    - `refactor`: A code change that neither fixes a bug nor adds a feature
-    - `ci`: Changes to our CI configuration files and scripts.
-
-2. You can optionally add a body that describes the commit in more detail.
-
-3. If your commit fixes an open issue, you can add a reference to it at the end of the log.
-
-    Examples:
-
-      - Fixes: https://issues.jboss.org/browse/AEROGEAR-8195
-      - Refs: https://issues.jboss.org/browse/AEROGEAR-8195
-
-4. If your commit introduces a breaking change (Semver Major), your commit message
-should explain what the breaking change is, the reason it was introduced, and which
-situation would trigger the breaking change.
-
-Sample complete commit message:
-
-```txt
-fix(module): explain the commit in one line. in most cases this is good enough.
-
-The body of the commit message is totally optional.
-You can use it to explaining things in more detail,
-possibly giving some background about the issue
-being fixed.
-
-Fixes: https://issues.jboss.org/browse/AEROGEAR-8192
-Refs: https://issues.jboss.org/browse/AEROGEAR-8193
-```
+- `doc`: Documentation only changes
+- `test`: Adding missing tests or correcting existing tests
+- `refactor`: A code change that neither fixes a bug nor adds a feature
+- `ci`: Changes to our CI configuration files and scripts.
 
 ### Step 5: Rebase
 

--- a/doc/guides/pull-requests.md
+++ b/doc/guides/pull-requests.md
@@ -78,32 +78,28 @@ A good commit message should describe what changed and why.
     - `refactor`: A code change that neither fixes a bug nor adds a feature
     - `ci`: Changes to our CI configuration files and scripts.
 
-2. Keep the second line blank
+2. You can optionally add a body that describes the commit in more detail.
 
-3. Try to keep all lines under 100 characters
-
-4. If your commit fixes an open issue, you can add a reference to it at the end of the log.
+3. If your commit fixes an open issue, you can add a reference to it at the end of the log.
 
     Examples:
 
       - Fixes: https://issues.jboss.org/browse/AEROGEAR-8195
       - Refs: https://issues.jboss.org/browse/AEROGEAR-8195
 
-5. If your commit introduces a breaking change (Semver Major), your commit message
+4. If your commit introduces a breaking change (Semver Major), your commit message
 should explain what the breaking change is, the reason it was introduced, and which
 situation would trigger the breaking change.
 
 Sample complete commit message:
 
 ```txt
-fix(module): explain the commit in one line
+fix(module): explain the commit in one line. in most cases this is good enough.
 
-Body of commit message is a few lines of text, explaining things
-in more detail, possibly giving some background about the issue
-being fixed, etc.
-
-Body of commit message may have multiple paragraphs if you wish.
-Please make sure the paragraphs are under 100 characters.
+The body of the commit message is totally optional.
+You can use it to explaining things in more detail,
+possibly giving some background about the issue
+being fixed.
 
 Fixes: https://issues.jboss.org/browse/AEROGEAR-8192
 Refs: https://issues.jboss.org/browse/AEROGEAR-8193

--- a/packages/apollo-voyager-keycloak/src/KeycloakSecurityService.ts
+++ b/packages/apollo-voyager-keycloak/src/KeycloakSecurityService.ts
@@ -43,6 +43,7 @@ export class KeycloakSecurityService implements SecurityService {
 
     this.log.info('Initializing Keycloak authentication')
     const memoryStore = new session.MemoryStore()
+
     expressRouter.use(session({
       secret: this.keycloakConfig.secret || 'secret',
       resave: false,


### PR DESCRIPTION
This PR mostly adds the boilerplate kind of documentation you would expect.

* License
* Code of Conduct
* Multiple Issue Templates (bug report, feature request, ask for help)
* Pull Request Template
* Code Owners
* Top level contributing guide that links to various different guides
* Various guides for opening issues, PRs, examples etc.
* Tidies up the Readme to point to other docs.

There is one major feature of this PR. It introduces a **commit message guideline**. I ask everyone that reviews this PR to please take a close look at these guidelines added in the Pull Requests guide.

Overall, the commit message guidelines are very simple to follow, and they provide a lot of value.

* Commit messages are more readable, especially when looking through the **project history**.
* Commit messages to describe whether a major, minor or patch change has been introduced (see [semver.org](https://semver.org/)).
* Commit messages can be used to generate a changelog.