### PR TITLE
AEROGEAR-8186 Move existing prometheus metrics functionality from syn…

### DIFF
--- a/examples/metrics/server.js
+++ b/examples/metrics/server.js
@@ -8,17 +8,6 @@ const { wrapResolversForMetrics, applyMetricsMiddleware, enableDefaultMetricsCol
 const typeDefs = gql`
   type Query {
     hello: String
-    getUser: User 
-  }
-
-  type User {
-    name: String
-    favoriteHorse: Horse
-  }
-
-  type Horse {
-    name: String
-    breed: String
   }
 `
 
@@ -27,14 +16,6 @@ let resolvers = {
   Query: {
     hello: (obj, args, context, info) => {
       return `Hello world from ${context.serverName}`
-    },
-    getUser: (obj, args, context, info) => {
-      return {name: 'Arthur Morgan'}
-    }
-  },
-  User:{
-    favoriteHorse: (obj, args, context, info) => {
-      return {name: 'Biscuit', breed: 'Arabian'}
     }
   }
 }

--- a/packages/apollo-voyager-metrics/package.json
+++ b/packages/apollo-voyager-metrics/package.json
@@ -24,7 +24,9 @@
   },
   "dependencies": {
     "prom-client": "^11.2.0",
-    "@aerogear/apollo-voyager-tools": "^1.0.0"
+    "@aerogear/apollo-voyager-tools": "^1.0.0",
+    "apollo-server": "^2.2.2",
+    "apollo-server-express": "^2.2.2"
   },
   "devDependencies": {
     "ava": "1.0.0-rc.2",

--- a/packages/apollo-voyager-metrics/src/index.ts
+++ b/packages/apollo-voyager-metrics/src/index.ts
@@ -42,18 +42,16 @@ export function enableDefaultMetricsColleciton () {
   }
 }
 
-export function wrapResolversForMetrics (resolvers: {[key: string]: ResolverObject}): {[key: string]: ResolverObject} {
+export function wrapResolversForMetrics (resolverMappings: {[key: string]: ResolverObject}): {[key: string]: ResolverObject} {
   const output: {[key: string]: ResolverObject} = {}
-  for (const typeKey in resolvers) {
-    if (!resolvers.hasOwnProperty(typeKey)) {
-      continue
-    }
-    const fieldResolversForType = resolvers[typeKey]
+
+  const typeKeys = Object.keys(resolverMappings)
+  for (const typeKey of typeKeys) {
     output[typeKey] = {}
-    for (const fieldKey in fieldResolversForType) {
-      if (!fieldResolversForType.hasOwnProperty(fieldKey)) {
-        continue
-      }
+
+    const fieldResolversForType = resolverMappings[typeKey]
+    const fieldKeysForType = Object.keys(fieldResolversForType)
+    for (const fieldKey of fieldKeysForType) {
       const resolverForField = fieldResolversForType[fieldKey]
       output[typeKey][fieldKey] = wrapSingleResolverForMetrics(resolverForField)
     }

--- a/packages/apollo-voyager-server/package.json
+++ b/packages/apollo-voyager-server/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@aerogear/apollo-voyager-context": "^1.0.0",
+    "@aerogear/apollo-voyager-metrics": "^1.0.0",
     "apollo-server": "^2.2.2",
     "apollo-server-express": "^2.2.2"
   },

--- a/packages/apollo-voyager-server/package.json
+++ b/packages/apollo-voyager-server/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@aerogear/apollo-voyager-context": "^1.0.0",
-    "@aerogear/apollo-voyager-metrics": "^1.0.0",
     "apollo-server": "^2.2.2",
     "apollo-server-express": "^2.2.2"
   },


### PR DESCRIPTION
…c server to its own library

As we decided, I picked the simplest approach.

Changes in examples/metrics/server.js is done to demonstrate how to make use of these changes.

Verificaiton:
1. Start it by `node examples/metrics/server.js `
2. ~~Execute this query bunch of times~~
```
query hello {
  getUser{name, favoriteHorse{name, breed}}
}
```
UPDATE: the metrics example is simplified now. Just execute `query hello {hello}`.
3. Go to http://localhost:4000/metrics
You will see these:
```
# HELP resolver_timing_ms Resolver response time in milliseconds
# TYPE resolver_timing_ms histogram
resolver_timing_ms_bucket{le="0.005",operation_type="query",name="Query.hello"} 0
resolver_timing_ms_bucket{le="0.01",operation_type="query",name="Query.hello"} 0
resolver_timing_ms_bucket{le="0.025",operation_type="query",name="Query.hello"} 0
resolver_timing_ms_bucket{le="0.05",operation_type="query",name="Query.hello"} 0
resolver_timing_ms_bucket{le="0.1",operation_type="query",name="Query.hello"} 0
resolver_timing_ms_bucket{le="0.25",operation_type="query",name="Query.hello"} 0
resolver_timing_ms_bucket{le="0.5",operation_type="query",name="Query.hello"} 0
resolver_timing_ms_bucket{le="1",operation_type="query",name="Query.hello"} 1
resolver_timing_ms_bucket{le="2.5",operation_type="query",name="Query.hello"} 1
resolver_timing_ms_bucket{le="5",operation_type="query",name="Query.hello"} 1
resolver_timing_ms_bucket{le="10",operation_type="query",name="Query.hello"} 1
resolver_timing_ms_bucket{le="+Inf",operation_type="query",name="Query.hello"} 1
resolver_timing_ms_sum{operation_type="query",name="Query.hello"} 1
resolver_timing_ms_count{operation_type="query",name="Query.hello"} 1

# HELP requests_resolved Number of requests resolved by server
# TYPE requests_resolved counter
requests_resolved{operation_type="query",path="Query.hello"} 1

# HELP requests_resolved_total Number of requests resolved by server in total
# TYPE requests_resolved_total counter
requests_resolved_total{operation_type="query",path="Query.hello"} 1

# HELP server_response_ms Server response time in milliseconds
# TYPE server_response_ms histogram
server_response_ms_bucket{le="0.005",request_type="GET",error="false"} 0
server_response_ms_bucket{le="0.01",request_type="GET",error="false"} 0
server_response_ms_bucket{le="0.025",request_type="GET",error="false"} 0
server_response_ms_bucket{le="0.05",request_type="GET",error="false"} 0
server_response_ms_bucket{le="0.1",request_type="GET",error="false"} 0
server_response_ms_bucket{le="0.25",request_type="GET",error="false"} 0
server_response_ms_bucket{le="0.5",request_type="GET",error="false"} 0
server_response_ms_bucket{le="1",request_type="GET",error="false"} 0
server_response_ms_bucket{le="2.5",request_type="GET",error="false"} 0
server_response_ms_bucket{le="5",request_type="GET",error="false"} 1
server_response_ms_bucket{le="10",request_type="GET",error="false"} 2
server_response_ms_bucket{le="+Inf",request_type="GET",error="false"} 2
server_response_ms_sum{request_type="GET",error="false"} 10
server_response_ms_count{request_type="GET",error="false"} 2
server_response_ms_bucket{le="0.005",request_type="GET",error="true"} 0
server_response_ms_bucket{le="0.01",request_type="GET",error="true"} 0
server_response_ms_bucket{le="0.025",request_type="GET",error="true"} 0
server_response_ms_bucket{le="0.05",request_type="GET",error="true"} 0
server_response_ms_bucket{le="0.1",request_type="GET",error="true"} 0
server_response_ms_bucket{le="0.25",request_type="GET",error="true"} 0
server_response_ms_bucket{le="0.5",request_type="GET",error="true"} 0
server_response_ms_bucket{le="1",request_type="GET",error="true"} 0
server_response_ms_bucket{le="2.5",request_type="GET",error="true"} 1
server_response_ms_bucket{le="5",request_type="GET",error="true"} 1
server_response_ms_bucket{le="10",request_type="GET",error="true"} 1
server_response_ms_bucket{le="+Inf",request_type="GET",error="true"} 1
server_response_ms_sum{request_type="GET",error="true"} 2
server_response_ms_count{request_type="GET",error="true"} 1
server_response_ms_bucket{le="0.005",request_type="POST",error="false"} 0
server_response_ms_bucket{le="0.01",request_type="POST",error="false"} 0
server_response_ms_bucket{le="0.025",request_type="POST",error="false"} 0
server_response_ms_bucket{le="0.05",request_type="POST",error="false"} 0
server_response_ms_bucket{le="0.1",request_type="POST",error="false"} 0
server_response_ms_bucket{le="0.25",request_type="POST",error="false"} 0
server_response_ms_bucket{le="0.5",request_type="POST",error="false"} 0
server_response_ms_bucket{le="1",request_type="POST",error="false"} 0
server_response_ms_bucket{le="2.5",request_type="POST",error="false"} 0
server_response_ms_bucket{le="5",request_type="POST",error="false"} 1
server_response_ms_bucket{le="10",request_type="POST",error="false"} 1
server_response_ms_bucket{le="+Inf",request_type="POST",error="false"} 2
server_response_ms_sum{request_type="POST",error="false"} 38
server_response_ms_count{request_type="POST",error="false"} 2```