### PR TITLE
Aerogear 8188 audit log module

### DIFF
--- a/examples/auditLogging/server.js
+++ b/examples/auditLogging/server.js
@@ -1,0 +1,48 @@
+const express = require('express')
+const { makeExecutableSchema } = require('graphql-tools')
+
+const { ApolloVoyagerServer, gql } = require('../../packages/apollo-voyager-server')
+const { setAuditLogEnabled, wrapResolversForAuditLogging} = require('../../packages/apollo-voyager-audit')
+
+// This is our Schema Definition Language (SDL)
+const typeDefs = gql`
+  type Query {
+    hello: String
+  }
+`
+
+// Resolver functions. This is our business logic
+let resolvers = {
+  Query: {
+    hello: (obj, args, context, info) => {
+      return `Hello world from ${context.serverName}`
+    }
+  }
+}
+
+setAuditLogEnabled(true)
+resolvers = wrapResolversForAuditLogging(resolvers)
+
+const schema = makeExecutableSchema({ typeDefs, resolvers })
+
+// The context is a function or object that can add some extra data
+// That will be available via the `context` argument the resolver functions
+const context = async ({ req }) => {
+  // add some context to GraphQL requests
+  console.log('my context provider')
+  return { serverName: 'Voyager Server' }
+}
+
+// Initialize the apollo voyager server with our schema and context
+const server = ApolloVoyagerServer({
+  schema,
+  context
+})
+
+const app = express()
+server.applyMiddleware({ app })
+
+const port = 4000
+app.listen({ port }, () =>
+  console.log(`🚀 Server ready at http://localhost:${port}${server.graphqlPath}`)
+)

--- a/examples/package.json
+++ b/examples/package.json
@@ -15,6 +15,7 @@
     "@aerogear/apollo-voyager-keycloak": "1.0.0",
     "@aerogear/apollo-voyager-server": "1.0.0",
     "@aerogear/apollo-voyager-metrics": "1.0.0",
+    "@aerogear/apollo-voyager-audit": "1.0.0",
     "express": "^4.16.4",
     "graphql-tools": "^4.0.3"
   },

--- a/packages/apollo-voyager-audit/.npmrc
+++ b/packages/apollo-voyager-audit/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/apollo-voyager-audit/README.md
+++ b/packages/apollo-voyager-audit/README.md
@@ -1,0 +1,11 @@
+# `@aerogear/apollo-voyager-audit`
+
+> TODO: description
+
+## Usage
+
+```
+const context = require('@aerogear/apollo-voyager-audit');
+
+// TODO: DEMONSTRATE API
+```

--- a/packages/apollo-voyager-audit/package.json
+++ b/packages/apollo-voyager-audit/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@aerogear/apollo-voyager-audit",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "compile": "tsc --build tsconfig.json",
+    "watch": "tsc --build tsconfig.json --watch",
+    "compile:clean": "tsc --build tsconfig.json --clean",
+    "test": "ava '*.test.ts' '**/*.test.ts'"
+  },
+  "dependencies": {
+    "@aerogear/apollo-voyager-tools": "^1.0.0",
+    "graphql-tools": "^4.0.3",
+    "pino": "^5.9.0"
+  },
+  "devDependencies": {
+    "@types/pino": "^5.8.2",
+    "ava": "1.0.0-rc.2",
+    "ts-node": "^7.0.1",
+    "typescript": "^3.1.6"
+  },
+  "author": "AeroGear Team<aerogear@googlegroups.com>",
+  "license": "Apache-2.0",
+  "ava": {
+    "compileEnhancements": false,
+    "extensions": [
+      "ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ]
+  }
+}

--- a/packages/apollo-voyager-audit/src/deleteme.test.ts
+++ b/packages/apollo-voyager-audit/src/deleteme.test.ts
@@ -1,0 +1,5 @@
+import test from 'ava'
+
+test('DELETE ME DUMMY', t => {
+  t.is(true, true)
+})

--- a/packages/apollo-voyager-audit/src/index.ts
+++ b/packages/apollo-voyager-audit/src/index.ts
@@ -1,0 +1,75 @@
+import { buildPath } from '@aerogear/apollo-voyager-tools'
+import { GraphQLResolveInfo } from 'graphql'
+import { IFieldResolver } from 'graphql-tools'
+import pino from 'pino'
+
+const log = pino()
+const auditLogger = log.child({tag: 'AUDIT'})
+
+let auditLogEnabled = false
+
+export function isAuditLogEnabled (): boolean {
+  return auditLogEnabled
+}
+
+export function setAuditLogEnabled (val: boolean): void {
+  auditLogEnabled = val
+}
+
+interface ResolverObject {
+  [key: string]: IFieldResolver<any, any>
+}
+
+export function wrapResolversForAuditLogging (resolverMappings: { [key: string]: ResolverObject }): { [key: string]: ResolverObject } {
+  const output: { [key: string]: ResolverObject } = {}
+
+  const typeKeys = Object.keys(resolverMappings)
+  for (const typeKey of typeKeys) {
+    output[typeKey] = {}
+
+    const fieldResolversForType = resolverMappings[typeKey]
+    const fieldKeysForType = Object.keys(fieldResolversForType)
+    for (const fieldKey of fieldKeysForType) {
+      const resolverForField = fieldResolversForType[fieldKey]
+      output[typeKey][fieldKey] = wrapSingleResolverForAuditLogging(resolverForField)
+    }
+  }
+
+  return output
+}
+
+export function auditLog (success: boolean, request: any, info: GraphQLResolveInfo, parent: any, args: any, msg: string) {
+  if (auditLogEnabled) {
+    auditLogger.info({
+      msg: msg || '',
+      requestId: request ? request.id : '',
+      operationType: info.operation.operation,
+      fieldName: info.fieldName,
+      parentTypeName: info.parentType.name,
+      path: buildPath(info.path),
+      success,
+      parent,
+      arguments: args
+    })
+  }
+}
+
+///////////////////////////
+
+function wrapSingleResolverForAuditLogging (resolverFn: IFieldResolver<any, any>): IFieldResolver<any, any> {
+  return (obj: any, args: any, context: any, info: any) => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const result = await resolverFn(obj, args, context, info)
+        auditLog(true, context.request, info, obj, args, '')
+        resolve(result)
+      } catch (error) {
+        // we only publish time in success. const timeTook
+        // NOPE: const timeTook = Date.now() - resolverStartTime
+        // NOPE: updateResolverMetrics(info, timeTook)
+        auditLog(false, context.request, info, obj, args, error.message)
+        reject(error)
+      }
+    })
+  }
+}

--- a/packages/apollo-voyager-audit/tsconfig.json
+++ b/packages/apollo-voyager-audit/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": []
+}

--- a/packages/apollo-voyager-metrics/src/index.ts
+++ b/packages/apollo-voyager-metrics/src/index.ts
@@ -1,4 +1,4 @@
-import { buildPath } from '@aerogear/apollo-voyager-tools'
+import { buildPath, wrapResolvers, ResolverObject } from '@aerogear/apollo-voyager-tools'
 import { NextFunction, Response } from 'express'
 import { Application } from 'express'
 import { IFieldResolver } from 'graphql-tools'
@@ -31,10 +31,6 @@ const serverResponseMetric = new Prometheus.Histogram({
   labelNames: ['request_type', 'error']
 })
 
-interface ResolverObject {
-  [key: string]: IFieldResolver<any, any>
-}
-
 export function enableDefaultMetricsColleciton () {
   if (!promMetricsEnabled) {
     Prometheus.collectDefaultMetrics()
@@ -43,21 +39,7 @@ export function enableDefaultMetricsColleciton () {
 }
 
 export function wrapResolversForMetrics (resolverMappings: {[key: string]: ResolverObject}): {[key: string]: ResolverObject} {
-  const output: {[key: string]: ResolverObject} = {}
-
-  const typeKeys = Object.keys(resolverMappings)
-  for (const typeKey of typeKeys) {
-    output[typeKey] = {}
-
-    const fieldResolversForType = resolverMappings[typeKey]
-    const fieldKeysForType = Object.keys(fieldResolversForType)
-    for (const fieldKey of fieldKeysForType) {
-      const resolverForField = fieldResolversForType[fieldKey]
-      output[typeKey][fieldKey] = wrapSingleResolverForMetrics(resolverForField)
-    }
-  }
-
-  return output
+    return wrapResolvers(resolverMappings, wrapSingleResolverForMetrics)
 }
 
 export function applyResponseLoggingMetricsMiddleware (app: Application) {

--- a/packages/apollo-voyager-metrics/src/index.ts
+++ b/packages/apollo-voyager-metrics/src/index.ts
@@ -1,7 +1,7 @@
 import { buildPath } from '@aerogear/apollo-voyager-tools'
 import { NextFunction, Response } from 'express'
 import { Application } from 'express'
-import { IFieldResolver, IResolvers } from 'graphql-tools'
+import { IFieldResolver } from 'graphql-tools'
 import { IncomingMessage } from 'http'
 import Prometheus from 'prom-client'
 

--- a/packages/apollo-voyager-tools/package.json
+++ b/packages/apollo-voyager-tools/package.json
@@ -9,6 +9,9 @@
     "test": "ava '*.test.ts' '**/*.test.ts'",
     "compile:clean": "tsc --build tsconfig.json --clean"
   },
+  "dependencies": {
+    "graphql-tools": "^4.0.3"
+  },
   "devDependencies": {
     "ava": "1.0.0-rc.2",
     "ts-node": "^7.0.1",

--- a/packages/apollo-voyager-tools/src/index.ts
+++ b/packages/apollo-voyager-tools/src/index.ts
@@ -1,1 +1,2 @@
 export * from './buildPath'
+export * from './wrapResolvers'

--- a/packages/apollo-voyager-tools/src/wrapResolvers.ts
+++ b/packages/apollo-voyager-tools/src/wrapResolvers.ts
@@ -1,0 +1,24 @@
+import { IFieldResolver } from 'graphql-tools'
+
+export interface ResolverObject {
+  [key: string]: IFieldResolver<any, any>
+}
+
+export function wrapResolvers (resolverMappings: { [key: string]: ResolverObject },
+                               resolverWrapper: (resolver: IFieldResolver<any, any>) => IFieldResolver<any, any>): { [key: string]: ResolverObject } {
+  const output: { [key: string]: ResolverObject } = {}
+
+  const typeKeys = Object.keys(resolverMappings)
+  for (const typeKey of typeKeys) {
+    output[typeKey] = {}
+
+    const fieldResolversForType = resolverMappings[typeKey]
+    const fieldKeysForType = Object.keys(fieldResolversForType)
+    for (const fieldKey of fieldKeysForType) {
+      const resolverForField = fieldResolversForType[fieldKey]
+      output[typeKey][fieldKey] = resolverWrapper(resolverForField)
+    }
+  }
+
+  return output
+}


### PR DESCRIPTION
Blocked by https://github.com/aerogear/apollo-voyager-server/pull/12

Similar to https://github.com/aerogear/apollo-voyager-server/pull/12, a dumb audit logging implementation.

Created a new server startup in examples dir.

Verification:
- Run `npm run bootstrap && npm run compile`` on `apollo-voyager-server`
- Run `npm install` on `apollo-voyager-server/examples`
- Run `node apollo-voyager-server/examples/auditLogging/server.js`
- Go to localhost:4000/graphql and execute bunch of queries
- You will see some JSON output in the console.