### PR TITLE
fix: Lock apollo-server to v2.2.2

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -1,0 +1,426 @@
+{
+	"name": "apollo-voyager-example",
+	"version": "0.1.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@types/graphql": {
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.0.3.tgz",
+			"integrity": "sha512-TcFkpEjcQK7w8OcrQcd7iIBPjU0rdyi3ldj6d0iJ4PPSzbWqPBvXj9KSwO14hTOX2dm9RoiH7VuxksJLNYdXUQ==",
+			"dev": true
+		},
+		"accepts": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"requires": {
+				"mime-types": "2.1.21",
+				"negotiator": "0.6.1"
+			}
+		},
+		"apollo-link": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.4.tgz",
+			"integrity": "sha512-B1z+9H2nTyWEhMXRFSnoZ1vSuAYP+V/EdUJvRx9uZ8yuIBZMm6reyVtr1n0BWlKeSFyPieKJy2RLzmITAAQAMQ==",
+			"requires": {
+				"apollo-utilities": "1.0.26",
+				"zen-observable-ts": "0.8.11"
+			}
+		},
+		"apollo-utilities": {
+			"version": "1.0.26",
+			"resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.26.tgz",
+			"integrity": "sha512-URw7o3phymliqYCYatcird2YRPUU2eWCNvip64U9gQrX56mEfK4m99yBIDCMTpmcvOFsKLii1sIEZsHIs/bvnw==",
+			"requires": {
+				"fast-json-stable-stringify": "2.0.0"
+			}
+		},
+		"array-flatten": {
+			"version": "1.1.1",
+			"resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+		},
+		"body-parser": {
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+			"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+			"requires": {
+				"bytes": "3.0.0",
+				"content-type": "1.0.4",
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"http-errors": "1.6.3",
+				"iconv-lite": "0.4.23",
+				"on-finished": "2.3.0",
+				"qs": "6.5.2",
+				"raw-body": "2.3.3",
+				"type-is": "1.6.16"
+			}
+		},
+		"bytes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+		},
+		"deprecated-decorator": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+			"integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+		},
+		"express": {
+			"version": "4.16.4",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+			"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+			"requires": {
+				"accepts": "1.3.5",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.3",
+				"content-disposition": "0.5.2",
+				"content-type": "1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"finalhandler": "1.1.1",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "1.1.2",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "2.0.4",
+				"qs": "6.5.2",
+				"range-parser": "1.2.0",
+				"safe-buffer": "5.1.2",
+				"send": "0.16.2",
+				"serve-static": "1.13.2",
+				"setprototypeof": "1.1.0",
+				"statuses": "1.4.0",
+				"type-is": "1.6.16",
+				"utils-merge": "1.0.1",
+				"vary": "1.1.2"
+			}
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
+		"finalhandler": {
+			"version": "1.1.1",
+			"resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+			"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"on-finished": "2.3.0",
+				"parseurl": "1.3.2",
+				"statuses": "1.4.0",
+				"unpipe": "1.0.0"
+			}
+		},
+		"forwarded": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+		},
+		"graphql-tools": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.3.tgz",
+			"integrity": "sha512-NNZM0WSnVLX1zIMUxu7SjzLZ4prCp15N5L2T2ro02OVyydZ0fuCnZYRnx/yK9xjGWbZA0Q58yEO//Bv/psJWrg==",
+			"requires": {
+				"apollo-link": "1.2.4",
+				"apollo-utilities": "1.0.26",
+				"deprecated-decorator": "0.1.6",
+				"iterall": "1.2.2",
+				"uuid": "3.3.2"
+			}
+		},
+		"http-errors": {
+			"version": "1.6.3",
+			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"requires": {
+				"depd": "1.1.2",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.0",
+				"statuses": "1.4.0"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+			"requires": {
+				"safer-buffer": "2.1.2"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"ipaddr.js": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+		},
+		"iterall": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+			"integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+		},
+		"mime": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+		},
+		"mime-db": {
+			"version": "1.37.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+		},
+		"mime-types": {
+			"version": "2.1.21",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+			"requires": {
+				"mime-db": "1.37.0"
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"negotiator": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
+		"parseurl": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+		},
+		"path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+		},
+		"proxy-addr": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+			"requires": {
+				"forwarded": "0.1.2",
+				"ipaddr.js": "1.8.0"
+			}
+		},
+		"qs": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+		},
+		"range-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+		},
+		"raw-body": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+			"requires": {
+				"bytes": "3.0.0",
+				"http-errors": "1.6.3",
+				"iconv-lite": "0.4.23",
+				"unpipe": "1.0.0"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"send": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "1.1.2",
+				"destroy": "1.0.4",
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"etag": "1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "1.6.3",
+				"mime": "1.4.1",
+				"ms": "2.0.0",
+				"on-finished": "2.3.0",
+				"range-parser": "1.2.0",
+				"statuses": "1.4.0"
+			}
+		},
+		"serve-static": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"requires": {
+				"encodeurl": "1.0.2",
+				"escape-html": "1.0.3",
+				"parseurl": "1.3.2",
+				"send": "0.16.2"
+			}
+		},
+		"setprototypeof": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+		},
+		"statuses": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+		},
+		"type-is": {
+			"version": "1.6.16",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "2.1.21"
+			}
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+		},
+		"uuid": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+		},
+		"zen-observable": {
+			"version": "0.8.11",
+			"resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.11.tgz",
+			"integrity": "sha512-N3xXQVr4L61rZvGMpWe8XoCGX8vhU35dPyQ4fm5CY/KDlG0F75un14hjbckPXTDuKUY6V0dqR2giT6xN8Y4GEQ=="
+		},
+		"zen-observable-ts": {
+			"version": "0.8.11",
+			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.11.tgz",
+			"integrity": "sha512-8bs7rgGV4kz5iTb9isudkuQjtWwPnQ8lXq6/T76vrepYZVMsDEv6BXaEA+DHdJSK3KVLduagi9jSpSAJ5NgKHw==",
+			"requires": {
+				"zen-observable": "0.8.11"
+			}
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7433,7 +7433,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {

--- a/packages/apollo-voyager-keycloak/package.json
+++ b/packages/apollo-voyager-keycloak/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@aerogear/apollo-voyager-server": "^1.0.0",
-    "apollo-server-express": "^2.2.2",
+    "apollo-server-express": "2.2.2",
     "express-session": "^1.15.6",
     "joi": "^14.3.0",
     "keycloak-connect": "^4.6.0",

--- a/packages/apollo-voyager-server/package.json
+++ b/packages/apollo-voyager-server/package.json
@@ -27,8 +27,9 @@
     "@aerogear/apollo-voyager-context": "^1.0.0",
     "@aerogear/apollo-voyager-metrics": "^1.0.0",
     "@aerogear/apollo-voyager-tools": "^1.0.0",
-    "apollo-server": "^2.2.2",
-    "apollo-server-express": "^2.2.2"
+    "apollo-server": "2.2.2",
+    "apollo-server-express": "2.2.2",
+    "graphql-tools": "^4.0.3"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.1.4",


### PR DESCRIPTION
 Supper easy fix. Locking is temporary. Going to file issue upstream to supply types for 2.3.0