### PR TITLE
Namespace audit logs

### DIFF
--- a/packages/apollo-voyager-audit/src/auditLog.ts
+++ b/packages/apollo-voyager-audit/src/auditLog.ts
@@ -4,18 +4,20 @@ import pino from 'pino'
 
 interface AuditLogger {
   info (log: {
-    msg: string
-    requestId: string
-    operationType: string
-    fieldName: string
-    parentTypeName: string
-    path: string
-    success: boolean
-    parent: any
-    arguments: any
-    clientInfo: any
-    authenticated: boolean
-    userInfo: any
+    audit: {
+      msg: string
+      requestId: string
+      operationType: string
+      fieldName: string
+      parentTypeName: string
+      path: string
+      success: boolean
+      parent: any
+      arguments: any
+      clientInfo: any
+      authenticated: boolean
+      userInfo: any
+    }
   }): void
 }
 
@@ -24,17 +26,19 @@ const auditLogger: AuditLogger = log.child({tag: 'AUDIT'})
 
 export function auditLog (success: boolean, context: any, info: GraphQLResolveInfo, parent: any, args: any, msg: string) {
   auditLogger.info({
-    msg: msg || '',
-    requestId: context && context.request ? context.request.id : '',
-    operationType: info.operation.operation,
-    fieldName: info.fieldName,
-    parentTypeName: info.parentType.name,
-    path: buildPath(info.path),
-    success,
-    parent,
-    arguments: args,
-    clientInfo: context && context.request && context.request.body && context.request.body.extensions && context.request.body.extensions.metrics || undefined,
-    authenticated: !!(context && context.auth && context.auth.isAuthenticated()),
-    userInfo: (context && context.auth && context.auth.accessToken) ? context.auth.accessToken.content : undefined
+    audit: {
+      msg: msg || '',
+      requestId: context && context.request ? context.request.id : '',
+      operationType: info.operation.operation,
+      fieldName: info.fieldName,
+      parentTypeName: info.parentType.name,
+      path: buildPath(info.path),
+      success,
+      parent,
+      arguments: args,
+      clientInfo: context && context.request && context.request.body && context.request.body.extensions && context.request.body.extensions.metrics || undefined,
+      authenticated: !!(context && context.auth && context.auth.isAuthenticated()),
+      userInfo: (context && context.auth && context.auth.accessToken) ? context.auth.accessToken.content : undefined
+    }
   })
 }


### PR DESCRIPTION
Somehow we ported the audit logging function without this namespace. Fixing it now