### PR TITLE
Object state check

### DIFF
--- a/packages/apollo-voyager-conflicts/src/states/HashObjectState.ts
+++ b/packages/apollo-voyager-conflicts/src/states/HashObjectState.ts
@@ -7,7 +7,6 @@ import { CONFLICT_LOGGER } from '../constants'
  * Object state manager using a hashing method provided by user
  */
 export class HashObjectState implements ObjectState {
-  private logger = debug.default(CONFLICT_LOGGER)
   private hash: (object: any) => string
 
   constructor(hashImpl: (object: any) => string) {

--- a/packages/apollo-voyager-conflicts/src/states/VersionedObjectState.ts
+++ b/packages/apollo-voyager-conflicts/src/states/VersionedObjectState.ts
@@ -19,10 +19,16 @@ export class VersionedObjectState implements ObjectState {
   private logger = debug.default(CONFLICT_LOGGER)
 
   public hasConflict(serverData: ObjectStateData, clientData: ObjectStateData) {
-    if (serverData.version && clientData.version &&
-      serverData.version !== clientData.version) {
-      this.logger(`Conflict when saving data. current: ${serverData}, client: ${clientData}`)
-      return true
+    if (serverData.version && clientData.version) {
+      if (serverData.version !== clientData.version) {
+        this.logger(`Conflict when saving data. current: ${serverData}, client: ${clientData}`)
+        return true
+      }
+    } else {
+      this.logger(
+        `Supplied object is missing version field required to determine conflict
+         server: ${serverData}
+         client: ${clientData}`)
     }
     return false
   }

--- a/packages/apollo-voyager-conflicts/test/VersionedObjectState.test.ts
+++ b/packages/apollo-voyager-conflicts/test/VersionedObjectState.test.ts
@@ -16,6 +16,14 @@ test('Without conflict', (t) => {
   t.deepEqual(objectState.hasConflict(serverData, clientData), false)
 })
 
+test('Missing version', (t) => {
+  const objectState = new VersionedObjectState()
+  const serverData = { name: 'AeroGear'}
+  const clientData = { name: 'AeroGear', version: 1 }
+
+  t.deepEqual(objectState.hasConflict(serverData, clientData), false)
+})
+
 test('Next state ', (t) => {
   const serverData = { name: 'AeroGear', version: 1 }
   const objectState = new VersionedObjectState()


### PR DESCRIPTION
Add info for developers in situations where method for checking version is used in resolver, however object itself is not configured to see it or database do not contain this field.