### PR TITLE
WIP: State persistence

### DIFF
--- a/packages/apollo-voyager-conflicts/package.json
+++ b/packages/apollo-voyager-conflicts/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "@types/chai": "^4.1.3",
-    "@types/debug": "0.0.31",
     "ava": "1.0.0-rc.2",
     "chai": "^4.1.2",
     "nyc": "^11.7.1",
@@ -30,7 +29,6 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "debug": "^4.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/apollo-voyager-conflicts/src/api/AuditInfo.ts
+++ b/packages/apollo-voyager-conflicts/src/api/AuditInfo.ts
@@ -1,7 +1,0 @@
-
-/**
- * Interface used to abstract conflict logging
- */
-export interface MetricsAuditInformation {
-  logMessage(message: string, tag?: string): void
-}

--- a/packages/apollo-voyager-conflicts/src/api/AuditInfo.ts
+++ b/packages/apollo-voyager-conflicts/src/api/AuditInfo.ts
@@ -1,0 +1,7 @@
+
+/**
+ * Interface used to abstract conflict logging
+ */
+export interface MetricsAuditInformation {
+  logMessage(message: string, tag?: string): void
+}

--- a/packages/apollo-voyager-conflicts/src/api/ConflictLogger.ts
+++ b/packages/apollo-voyager-conflicts/src/api/ConflictLogger.ts
@@ -1,0 +1,7 @@
+
+/**
+ * Interface used to abstract conflict logging
+ */
+export interface ConflictLogger {
+  info(message: string): void
+}

--- a/packages/apollo-voyager-conflicts/src/api/ObjectConflictError.ts
+++ b/packages/apollo-voyager-conflicts/src/api/ObjectConflictError.ts
@@ -33,10 +33,10 @@ export interface ConflictData {
  * Error specific to Voyager framework
  */
 export class ObjectConflictError extends GraphQLError {
-  public conflictInfo: any
+  public conflictInfo: ConflictData
 
   constructor(data: ConflictData) {
-    super('VoyagerConflict')
+    super('GraphQLConflict')
     this.conflictInfo = data
   }
 }

--- a/packages/apollo-voyager-conflicts/src/api/ObjectConflictError.ts
+++ b/packages/apollo-voyager-conflicts/src/api/ObjectConflictError.ts
@@ -20,6 +20,11 @@ export interface ConflictData {
   clientData?: ObjectStateData
 
   /**
+   * Base data that before server side changes that caused conflict were applied
+   */
+  baseData?: ObjectStateData
+
+  /**
    * Flag used to inform client that conflict was already resolved on the server
    * and no further processing is needed. When flag is true `serverData` field will contain
    * resolved information. If value is false client will need to resolve conflict on their side

--- a/packages/apollo-voyager-conflicts/src/api/ObjectState.ts
+++ b/packages/apollo-voyager-conflicts/src/api/ObjectState.ts
@@ -9,14 +9,12 @@ import { ObjectStateData } from './ObjectStateData'
 export interface ObjectState {
 
   /**
-   *
    * @param serverData the data currently on the server
    * @param clientData the data the client wishes to perform some mutation with
    */
   hasConflict(serverData: ObjectStateData, clientData: ObjectStateData): boolean
 
   /**
-   *
    * @param currentObjectState the object wish you would like to progress to its next state
    */
   nextState(currentObjectState: ObjectStateData): ObjectStateData

--- a/packages/apollo-voyager-conflicts/src/api/ObjectState.ts
+++ b/packages/apollo-voyager-conflicts/src/api/ObjectState.ts
@@ -1,4 +1,5 @@
 import { ObjectStateData } from './ObjectStateData'
+import { StatePersistence } from './StatePersistence'
 
 /**
  * Interface for handling changing state of the object.
@@ -17,5 +18,22 @@ export interface ObjectState {
   /**
    * @param currentObjectState the object wish you would like to progress to its next state
    */
-  nextState(currentObjectState: ObjectStateData): ObjectStateData
+  nextState(currentObjectState: ObjectStateData): Promise<ObjectStateData>
+
+  /**
+   * Gets previous state from state persistence api
+   *
+   * @see enableDataHistory to enable state persistence api
+   * @param currentObjectState
+   */
+  previousState(currentObjectState: ObjectStateData): Promise<ObjectStateData>
+
+  /**
+   * Enables state persistence for ObjectState
+   * State persistence allows to retrieve previous versions of the
+   * objects in order to resolve data conflicts
+   *
+   * @param statePersistence implementation for state persistence
+   */
+  enableStatePersistence(statePersistence: StatePersistence): void
 }

--- a/packages/apollo-voyager-conflicts/src/api/ObjectState.ts
+++ b/packages/apollo-voyager-conflicts/src/api/ObjectState.ts
@@ -1,3 +1,4 @@
+import { ConflictLogger } from './ConflictLogger'
 import { ObjectStateData } from './ObjectStateData'
 import { StatePersistence } from './StatePersistence'
 
@@ -36,4 +37,10 @@ export interface ObjectState {
    * @param statePersistence implementation for state persistence
    */
   enableStatePersistence(statePersistence: StatePersistence): void
+
+  /**
+   * Enable logging for conflict resolution package
+   * @param logger - logger implementation
+   */
+  enableLogging(logger: ConflictLogger): void
 }

--- a/packages/apollo-voyager-conflicts/src/api/StatePersistence.ts
+++ b/packages/apollo-voyager-conflicts/src/api/StatePersistence.ts
@@ -1,0 +1,21 @@
+import { ObjectStateData } from './ObjectStateData'
+
+/**
+ * Provides ability to save previous versions of the data in order to provide
+ * ability to know state of the data before both changes occurred.
+ * giving ability to perform 2 way merge conflict resolution on server and client
+ */
+export interface StatePersistence {
+
+  /**
+   * Persist previous version of the object
+   * @param previous - object data before update was performed
+   */
+  persist(previous: ObjectStateData): Promise<ObjectStateData>
+
+  /**
+   * Fetch base version for specified object.
+   * Implementation allows users to fetch data before conflict happened
+   */
+  fetch(current: ObjectStateData): Promise<ObjectStateData>
+}

--- a/packages/apollo-voyager-conflicts/src/conflictHandlers/handleConflictOnClient.ts
+++ b/packages/apollo-voyager-conflicts/src/conflictHandlers/handleConflictOnClient.ts
@@ -2,9 +2,6 @@ import debug from 'debug'
 import { ConflictResolutionHandler } from '../api/ConflictHandler'
 import { ObjectConflictError } from '../api/ObjectConflictError'
 import { ObjectStateData } from '../api/ObjectStateData'
-import { CONFLICT_LOGGER } from '../constants'
-
-const logger = debug(CONFLICT_LOGGER)
 
 /**
  * @param currentRecord the object state that the server knows about
@@ -12,10 +9,6 @@ const logger = debug(CONFLICT_LOGGER)
  */
 export const handleConflictOnClient: ConflictResolutionHandler =
   (serverState: ObjectStateData, clientState: ObjectStateData) => {
-    logger(`Conflict detected.
-    Sending data to resolve conflict on client
-    Server: ${serverState} client: ${clientState}`)
-
     throw new ObjectConflictError({
       clientData: clientState,
       serverData: serverState,

--- a/packages/apollo-voyager-conflicts/src/index.ts
+++ b/packages/apollo-voyager-conflicts/src/index.ts
@@ -2,6 +2,8 @@
 export * from './api/ObjectState'
 export * from './api/ObjectConflictError'
 export * from './api/ObjectStateData'
+export * from './api/StatePersistence'
+export * from './api/ConflictLogger'
 
 // State implementations
 export * from './states/VersionedObjectState'

--- a/packages/apollo-voyager-conflicts/src/states/HashObjectState.ts
+++ b/packages/apollo-voyager-conflicts/src/states/HashObjectState.ts
@@ -1,13 +1,13 @@
-import * as debug from 'debug'
 import { ObjectState } from '../api/ObjectState'
 import { ObjectStateData } from '../api/ObjectStateData'
-import { CONFLICT_LOGGER } from '../constants'
+import { StatePersistence } from '../api/StatePersistence'
 
 /**
  * Object state manager using a hashing method provided by user
  */
 export class HashObjectState implements ObjectState {
   private hash: (object: any) => string
+  private statePersistence?: StatePersistence
 
   constructor(hashImpl: (object: any) => string) {
     this.hash = hashImpl
@@ -20,8 +20,21 @@ export class HashObjectState implements ObjectState {
     return false
   }
 
-  public nextState(currentObjectState: ObjectStateData) {
+  public async nextState(currentObjectState: ObjectStateData) {
+    if (this.statePersistence) {
+      this.statePersistence.persist(currentObjectState)
+    }
     // Hash can be calculated at any time and it is not added to object
     return currentObjectState
+  }
+
+  public async previousState(currentObjectState: ObjectStateData) {
+    if (this.statePersistence) {
+      return await this.statePersistence.fetch(currentObjectState)
+    }
+  }
+
+  public enableStatePersistence(statePersistence: StatePersistence): void {
+    this.statePersistence = statePersistence
   }
 }

--- a/packages/apollo-voyager-conflicts/src/states/HashObjectState.ts
+++ b/packages/apollo-voyager-conflicts/src/states/HashObjectState.ts
@@ -1,3 +1,4 @@
+import { ConflictLogger } from '../api/ConflictLogger'
 import { ObjectState } from '../api/ObjectState'
 import { ObjectStateData } from '../api/ObjectStateData'
 import { StatePersistence } from '../api/StatePersistence'
@@ -6,6 +7,7 @@ import { StatePersistence } from '../api/StatePersistence'
  * Object state manager using a hashing method provided by user
  */
 export class HashObjectState implements ObjectState {
+  private logger: ConflictLogger | undefined
   private hash: (object: any) => string
   private statePersistence?: StatePersistence
 
@@ -15,6 +17,10 @@ export class HashObjectState implements ObjectState {
 
   public hasConflict(serverData: ObjectStateData, clientData: ObjectStateData) {
     if (this.hash(serverData) !== this.hash(clientData)) {
+      if (this.logger) {
+        this.logger.info(`Conflict when saving data.
+        current: ${serverData}, client: ${clientData}`)
+      }
       return true
     }
     return false
@@ -22,6 +28,9 @@ export class HashObjectState implements ObjectState {
 
   public async nextState(currentObjectState: ObjectStateData) {
     if (this.statePersistence) {
+      if (this.logger) {
+        this.logger.info(`Persisting current state ${currentObjectState}`)
+      }
       this.statePersistence.persist(currentObjectState)
     }
     // Hash can be calculated at any time and it is not added to object
@@ -37,4 +46,9 @@ export class HashObjectState implements ObjectState {
   public enableStatePersistence(statePersistence: StatePersistence): void {
     this.statePersistence = statePersistence
   }
+
+  public enableLogging(logger: ConflictLogger): void {
+    this.logger = logger
+  }
+
 }

--- a/packages/apollo-voyager-conflicts/src/states/VersionedObjectState.ts
+++ b/packages/apollo-voyager-conflicts/src/states/VersionedObjectState.ts
@@ -1,8 +1,7 @@
-import * as debug from 'debug'
+import { ConflictLogger } from '../api/ConflictLogger'
 import { ObjectState } from '../api/ObjectState'
 import { ObjectStateData } from '../api/ObjectStateData'
 import { StatePersistence } from '../api/StatePersistence'
-import { CONFLICT_LOGGER } from '../constants'
 
 /**
  * Object state manager using a version field
@@ -17,20 +16,23 @@ import { CONFLICT_LOGGER } from '../constants'
  * }
  */
 export class VersionedObjectState implements ObjectState {
-  private logger = debug.default(CONFLICT_LOGGER)
   private statePersistence?: StatePersistence
+  private logger: ConflictLogger | undefined
 
   public hasConflict(serverData: ObjectStateData, clientData: ObjectStateData) {
     if (serverData.version && clientData.version) {
       if (serverData.version !== clientData.version) {
-        this.logger(`Conflict when saving data. current: ${serverData}, client: ${clientData}`)
+        if (this.logger) {
+          this.logger.info(`Conflict when saving data.
+          current: ${serverData}, client: ${clientData}`)
+        }
         return true
       }
-    } else {
-      this.logger(
+    } else if (this.logger) {
+      this.logger.info(
         `Supplied object is missing version field required to determine conflict
-         server: ${serverData}
-         client: ${clientData}`)
+         server: ${ serverData}
+         client: ${ clientData}`)
     }
     return false
   }
@@ -39,19 +41,28 @@ export class VersionedObjectState implements ObjectState {
     if (this.statePersistence) {
       await this.statePersistence.persist(currentObjectState)
     }
-    this.logger(`Moving object to next state, ${currentObjectState}`)
+    if (this.logger) {
+      this.logger.info(`Moving object to next state, ${currentObjectState}`)
+    }
     currentObjectState.version = currentObjectState.version + 1
     return currentObjectState
   }
 
   public async previousState(currentObjectState: ObjectStateData) {
     if (this.statePersistence) {
+      if (this.logger) {
+        this.logger.info(`Fetching previous state ${currentObjectState}`)
+      }
       return await this.statePersistence.fetch(currentObjectState)
     }
   }
 
   public enableStatePersistence(statePersistence: StatePersistence): void {
     this.statePersistence = statePersistence
+  }
+
+  public enableLogging(logger: ConflictLogger): void {
+    this.logger = logger
   }
 }
 

--- a/packages/apollo-voyager-conflicts/test/HashObjectState.test.ts
+++ b/packages/apollo-voyager-conflicts/test/HashObjectState.test.ts
@@ -16,9 +16,9 @@ test('Without conflict', (t) => {
   t.deepEqual(objectState.hasConflict(serverData, clientData), false)
 })
 
-test('Next state ', (t) => {
+test('Next state ', async (t) => {
   const serverData = { name: 'AeroGear' }
   const objectState = new HashObjectState((data) => JSON.stringify(data))
-  const next = objectState.nextState(serverData)
+  const next = await objectState.nextState(serverData)
   t.deepEqual(serverData, next)
 })

--- a/packages/apollo-voyager-conflicts/test/VersionedObjectState.test.ts
+++ b/packages/apollo-voyager-conflicts/test/VersionedObjectState.test.ts
@@ -24,9 +24,9 @@ test('Missing version', (t) => {
   t.deepEqual(objectState.hasConflict(serverData, clientData), false)
 })
 
-test('Next state ', (t) => {
+test('Next state ', async (t) => {
   const serverData = { name: 'AeroGear', version: 1 }
   const objectState = new VersionedObjectState()
-  const next = objectState.nextState(serverData)
+  const next = await objectState.nextState(serverData)
   t.deepEqual(next.version, 2)
 })


### PR DESCRIPTION
## Motivation:
To resolve conflicts users sometimes will need to know the state before both modifications were happening. This will enable developers to see differences in their api. StatePersistence is an really simple abstraction that users can reuse to provide conflict base. Interface is optional giving users additional capabilities without forcing them to implement Persistence layer. Example persistence layer could be in memory or utilize database.

## Progress 

- [x] Implementation
- [ ] Tests
- [ ] Documentation
- [ ] Example app updates