### PR TITLE
fix: ensure null values in VoyagerConfig do not override defaults

### DIFF
--- a/packages/apollo-voyager-server/src/config/DefaultVoyagerConfig.test.ts
+++ b/packages/apollo-voyager-server/src/config/DefaultVoyagerConfig.test.ts
@@ -1,5 +1,8 @@
 import test from 'ava'
+import { GraphQLResolveInfo } from 'graphql'
 
+import { AuditLogger } from '../audit'
+import { DefaultAuditLogger } from '../audit/DefaultAuditLogger'
 import { DefaultSecurityService } from '../security/DefaultSecurityService'
 import { SecurityService } from '../security/SecurityService'
 import { DefaultVoyagerConfig } from './DefaultVoyagerConfig'
@@ -9,6 +12,7 @@ test('DefaultVoyagerConfig returns a blank security service by default', async (
 
   t.truthy(voyagerConfig.securityService)
   t.truthy(voyagerConfig.securityService instanceof DefaultSecurityService)
+  t.truthy(voyagerConfig.auditLogger instanceof DefaultAuditLogger)
 })
 
 test('DefaultVoyagerConfig.merge() will override default security service with user supplied one', async (t) => {
@@ -30,4 +34,31 @@ test('DefaultVoyagerConfig.merge() will override default security service with u
 
   t.truthy(voyagerConfig.securityService)
   t.truthy(voyagerConfig.securityService instanceof DummySecurityService)
+})
+
+test('DefaultVoyagerConfig.merge() will override default audit logger with user supplied one', async (t) => {
+
+  class DummyAuditLogger implements AuditLogger {
+    public logResolverCompletion (msg: string, success: boolean, obj: any, args: any, context: any, info: GraphQLResolveInfo): void {
+      // no op
+    }
+
+    public auditLog (msg: string, obj: any, args: any, context: any, info: GraphQLResolveInfo): void {
+      // no op
+    }
+  }
+
+  const auditLogger = new DummyAuditLogger()
+  const voyagerConfig = new DefaultVoyagerConfig().merge({ auditLogger })
+
+  t.truthy(voyagerConfig.auditLogger)
+  t.truthy(voyagerConfig.auditLogger instanceof DummyAuditLogger)
+})
+
+test('DefaultVoyagerConfig.merge() will still give you defaults if user explicitly sets them to null', (t) => {
+  const voyagerConfig = new DefaultVoyagerConfig().merge({ securityService: null, auditLogger: null })
+
+  t.truthy(voyagerConfig.securityService)
+  t.truthy(voyagerConfig.securityService instanceof DefaultSecurityService)
+  t.truthy(voyagerConfig.auditLogger instanceof DefaultAuditLogger)
 })

--- a/packages/apollo-voyager-server/src/config/DefaultVoyagerConfig.ts
+++ b/packages/apollo-voyager-server/src/config/DefaultVoyagerConfig.ts
@@ -4,6 +4,11 @@ import { DefaultSecurityService } from '../security/DefaultSecurityService'
 import { SecurityService } from '../security/SecurityService'
 import { VoyagerConfig } from './VoyagerConfig'
 
+interface UserVoyagerConfig {
+  securityService?: SecurityService | null
+  auditLogger?: AuditLogger | null
+}
+
 export class DefaultVoyagerConfig implements VoyagerConfig {
   /**
    * Optional security service to be applied
@@ -11,7 +16,11 @@ export class DefaultVoyagerConfig implements VoyagerConfig {
   public securityService: SecurityService = new DefaultSecurityService()
   public auditLogger: AuditLogger = new DefaultAuditLogger()
 
-  public merge (userConfig: VoyagerConfig) {
-    return Object.assign(this, userConfig)
+  public merge (userConfig: UserVoyagerConfig) {
+    if (userConfig) {
+      this.securityService = (userConfig.securityService) ? userConfig.securityService : this.securityService
+      this.auditLogger = (userConfig.auditLogger) ? userConfig.auditLogger : this.auditLogger
+    }
+    return this
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/aerogear/apollo-voyager-server/blob/master/CONTRIBUTING.md
-->

### Description

There was a small bug if the user puts does something like this:

```
const voyagerConfig = {
  securityService: null,
}
ApolloVoyagerServer(apolloConfig, voyagerConfig)
```

then the default security service / audit logger can be set to null which will cause errors to be thrown in other places.

This PR fixes that bug and adds a test for that case.

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](../doc/guides/pull-requests.md#commit-message-guidelines)